### PR TITLE
[Docs] Fix `--host` style in some pages.

### DIFF
--- a/docs/configuration_guides/multibots.rst
+++ b/docs/configuration_guides/multibots.rst
@@ -107,7 +107,7 @@ If you wish to access the Dashboard on a device that is connected to the same ne
 
 .. tip::
 
-   If you choose this option, registering the redirect won't be necessary if you use directly the `--host` cli flag.
+   If you choose this option, registering the redirect won't be necessary if you use directly the ``--host`` cli flag.
 
 Registering the redirect
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/configuration_guides/singlebot.rst
+++ b/docs/configuration_guides/singlebot.rst
@@ -84,7 +84,7 @@ If you wish to access the Dashboard on a device that is connected to the same ne
 
 .. tip::
 
-   If you choose this option, registering the redirect won't be necessary if you use directly the `--host` cli flag.
+   If you choose this option, registering the redirect won't be necessary if you use directly the ``--host`` cli flag.
 
 Registering the redirect
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reverse_proxy_guides/reverse_proxy_nginx.rst
+++ b/docs/reverse_proxy_guides/reverse_proxy_nginx.rst
@@ -56,7 +56,7 @@ You probably don't want people visiting your domain to see that static Nginx wel
 
 .. warning::
 
-    You should use ``localhost`` instead of ``0.0.0.0`` to make the "real" webserver port private, and use the `--host localhost` cli flag for starting the webserver.
+    You should use ``localhost`` instead of ``0.0.0.0`` to make the "real" webserver port private, and use the ``--host localhost`` cli flag for starting the webserver.
 
 4. Enable the file by creating a link from it to the sites-enabled directory.
 


### PR DESCRIPTION
Fixed that it looks like a `-host` and not `--host`
example how it looked:
<img width="850" height="168" alt="image" src="https://github.com/user-attachments/assets/0e07abf1-e8d9-45b9-8843-d3e6553d1ccf" />

Fixed in multibot, singlebot and reverse proxy, looks like caddy was already fixed:
<img width="868" height="171" alt="image" src="https://github.com/user-attachments/assets/161f0533-8ba9-4b0a-90f5-db6821bafe60" />
