### PR TITLE
Fix compatibility issue with Flask-WTF 1.3.0 inside protect definition.

### DIFF
--- a/reddash/app/utils.py
+++ b/reddash/app/utils.py
@@ -223,8 +223,8 @@ def register_extensions(_app: Flask) -> None:
     app.csrf_protect.init_app(app)
     initial_protect = app.csrf_protect.protect
 
-    def protect():
-        initial_protect()
+    def protect(*args, **kwargs):
+        initial_protect(*args, **kwargs)
         g.csrf_valid = False
 
     app.csrf_protect.protect = protect


### PR DESCRIPTION
Flask-WTF 1.3.0 updated their internal `protect()` method to pass `apply_exemptions=True` as a keyword argument
Updated the wrapper to use `*args` and `**kwargs` so arguments are passed through correctly